### PR TITLE
Correct description of implementation tagging

### DIFF
--- a/traceability/tooling.md
+++ b/traceability/tooling.md
@@ -344,7 +344,7 @@ between specifications and implementation, using [TRC-IMPL.1::PREFIX.1][].
 
 |HW.1::INPUT.1::ASKNAME.1|
 : The software must ask the user for their name, and receive the input given in
-  resonse.
+  response.
 
 ## Output
 

--- a/traceability/tooling.md
+++ b/traceability/tooling.md
@@ -326,7 +326,7 @@ For each project, we therefore need two types of configuration:
 
 ### Sample Referencing Approach
 
-The following outlines a trivial example of how one could capture the trances
+The following outlines a trivial example of how one could capture the traces
 between specifications and implementation, using [TRC-IMPL.1::PREFIX.1][].
 
 #### Sample Specification

--- a/traceability/tooling.md
+++ b/traceability/tooling.md
@@ -326,71 +326,73 @@ For each project, we therefore need two types of configuration:
 
 ### Sample Referencing Approach
 
-The following sample outlines a trivial example of how one could facilitate
-traceability from specifications through to code.
+The following outlines a trivial example of how one could capture the trances
+between specifications and implementation, using [TRC-IMPL.1::PREFIX.1][].
 
 #### Sample Specification
 
 ```markdown
 # Hello World
 
+|HW.1|
+: A program to great the world.
+
 ## User Input
 
-|HW-INPUT.1::ASKNAME.1|
-: The software must ask the user for their name.
+|HW.1.::INPUT.1|
+: The software must be able to handle specified forms of input.
+
+|HW.1::INPUT.1::ASKNAME.1|
+: The software must ask the user for their name, and receive the input given in
+  resonse.
 
 ## Output
 
-|HW-OUTPUT.1::HELLO.1|
+|HW.1::OUTPUT.1|
+: The software must produce certain outputs, based on the [HW.1::INPUT.1].
+
+|HW.1::OUTPUT.1::HELLO.1|
 : Once the software has asked for the user's name, it must print the text
   "Hello {user name}!".
 
   The `{user name}` part of the output string must be replaced with the name of
-  the user obtained in [HW-INPUT.1::ASKNAME.1].
+  the user obtained in [HW.1::INPUT.1::ASKNAME.1].
 
-|HW-OUTPUT.1::FOUNDHIM.1|
+|HW.1::OUTPUT.1::FOUNDHIM.1|
 : If the user's name is "Waldo", in addition to saying hello to the user as per
-  [HW-OUTPUT.1::HELLO.1], print the text: "We found you!".
+  [HW.1::OUTPUT.1::HELLO.1], print the text: "We found you!".
 ```
-
-This specification would be parsed into the following requirements:
-
-* `HW-INPUT.1::ASKNAME.1` - The software must ask the user for their name.
-* `HW-OUTPUT.1::HELLO.1` - Once the software has asked for the user's name, it
-  must print the text "Hello {user name}!".
-
-  The `{user name}` part of the output string must be replaced with the name of
-  the user obtained in `HW-INPUT.1::ASKNAME.1`.
-* `HW-OUTPUT.1::FOUNDHIM.1` - If the user's name is "Waldo", in addition to
-  saying hello to the user as per `[HW-OUTPUT.1::HELLO.1]`, print the text: "We
-  found you!".
 
 #### Sample Code
 
 ```rust
 use std::io;
 
-/**
- * Checks whether the specified name is "Waldo". Implements
- * [HW-OUTPUT.1::FOUNDHIM.1]. This tag applies to the whole function.
- */
+/// Checks whether the specified name is "Waldo". 
+/// 
+/// This tag applies to the whole function.
+///
+/// |HW.1::OUTPUT.1::FOUNDHIM.1:::CHECK.1|
 fn check_for_waldo(name: &str) {
     if name == "Waldo" {
         println!("We found you!");
     }
 }
 
+/// |HW.1::MAIN.1|
 fn main() {
     let mut name = String::new();
 
     // The following tag applies only to the line directly underneath it.
-    // [HW-INPUT.1::ASKNAME.1]
+    //
+    // |HW.1::INPUT.1::ASKNAME.1::IMP.1|
     println!("Hi there! What's your name?");
 
+    // |HW.1.::INPUT.1::READ-LINE.1|
     match io::stdin().read_line(&mut name) {
         Ok(_) => {
             let name_trimmed = name.trim();
-            // [HW-OUTPUT.1::HELLO.1]
+            // |HW.1::OUTPUT.1::HELLO.1::IMP.1|
             println!("Hello {}!", name_trimmed);
             check_for_waldo(name_trimmed);
         },
@@ -423,3 +425,5 @@ fn main() {
 [22]: https://doorstop.readthedocs.io/en/latest/
 [23]: https://gitlab.com/groups/gitlab-org/-/epics/2703
 [24]: https://github.github.com/gfm/
+
+[TRC-IMPL.1::PREFIX.1]: ./traceability.md#TRC-IMPL.1::PREFIX.1

--- a/traceability/tooling.md
+++ b/traceability/tooling.md
@@ -335,7 +335,7 @@ between specifications and implementation, using [TRC-IMPL.1::PREFIX.1][].
 # Hello World
 
 |HW.1|
-: A program to great the world.
+: A program to greet the world.
 
 ## User Input
 

--- a/traceability/traceability.md
+++ b/traceability/traceability.md
@@ -164,7 +164,7 @@ We need a solution that satisfies the following properties:
 
 ### 4.4. Implementing logical units
 
-|TRC-IMPL.1::PREFIX.1|
+<a id="TRC-IMPL.1::PREFIX.1">|TRC-IMPL.1::PREFIX.1|</a>
 : The fact that a logical unit implements another logical unit is reflected by
   the tag naming scheme. The name of a tag of level `k` has the form
   `<PARENT>::<NAME>.<REVISION>`. The name indicates that the logical unit


### PR DESCRIPTION
I think we initially missed a detail of the spec. As per
[TRC-IMPL.1::PREFIX.1][], an implementation unit is to be tagged with
it's own pipe-designated tag that adds a suffix.

This is important for two reasons:

1. It makes tagging implementation units trivial, in that we don't need
to introduce new syntax (such as the `## Implements`
header I proposed elsewhere).
2. It provides a unique tag for each implementation unit, which is
critical for when we decompose a spec into many smaller implementation
aspects, and for allowing unique reference from verification units, or
other implementation units (e.g., when using a reference implementation
as a spec).

[TRC-IMPL.1::PREFIX.1]: https://github.com/informalsystems/vdd/blob/master/traceability/traceability.md#TRC-IMPL.1::PREFIX.1