### PR TITLE
Introduce support for tag synonymy

### DIFF
--- a/traceability/traceability.md
+++ b/traceability/traceability.md
@@ -127,14 +127,18 @@ We need a solution that satisfies the following properties:
   as the tags always come with revision numbers.
 
 |TRC-TAG.1::SYNTAX.1::SYNONYMY.1| |TRC-IMPL.1::SYNONYMY.1|
-: A logical unit may bear multiple tags, as a result of implementing multiple
-  ancestor logical units. This gives rise to "synonyms tags". However, logical
-  units with synonymous tags should always terminate with the same leaf tag.
+: Non-zero-level requirement tags (described above) record the "ancestry" of the
+  higher level units they implement. When a logical unit implements multiple
+  units from a higher level, it has multiple parents, multiple lines of
+  ancestry, and, consequently, multiple valid tags. In such  cases, we end up
+  with two or more tags which refer to the same logical unit. These tags are
+  *synonymous* (in terms of reference, but not sense) so we refer to this as
+  "tag synonymy".
 
-  A logical unit is tagged with synonymous tags by separating the synonyms
-  with a space. Given a unit with the leaf tag `T` that implements `n` ancestor
-  units with paths `path[0]...path[n]`, the unit is tagged with `|path[0]::T|
-  |path[1]::T| ... |path[n]::T|`.
+  A logical unit is tagged with synonymous tags by separating the synonyms with
+  spaces. Given a unit designated by the leaf tag `T` that implements `n`
+  ancestor units with paths `path[0]...path[n]`, the unit is tagged with
+  `|path[0]::T| |path[1]::T| ... |path[n]::T|`.
 
 Example: The previous logical unit implements both [TRC-TAG.1::SYNTAX.1] and
 [TRC-IMPL.1]. As a result, it is tagged with both

--- a/traceability/traceability.md
+++ b/traceability/traceability.md
@@ -126,6 +126,39 @@ We need a solution that satisfies the following properties:
   programmers. There is no danger of confusing a Rust package name with a tag,
   as the tags always come with revision numbers.
 
+|TRC-TAG.1::SYNTAX.1::SYNONYMY.1| |TRC-IMPL.1::SYNONYMY.1|
+: A logical unit may bear multiple tags, as a result of implementing multiple
+  ancestor logical units. This gives rise to "synonyms tags". However, logical
+  units with synonymous tags should always have a unique leaf tag.
+
+  A logical unit is tagged with synonymous tags by separating the synonymous
+  with a space. Given a unit with the leaf tag `T` that implements `n` ancestor
+  units with paths `path[0]...path[n]`, the unit is tagged with `|path[0]::T|
+  |path[1]::T| ... |path[n]::T|`.
+
+Example: The previous logical unit implements both [TRC-TAG.1::SYNTAX.1] and
+[TRC-IMPL.1]. As a result, it is tagged with both
+[TRC-TAG.1::SYNTAX.1::SYNONYMY.1] and [TRC-IMPL.1::SYNONYMY.1], and so these two
+tags are synonymous. However, it also bears the univocal leaf tag `SYNONYMY.1`
+
+|{TRC-TAG.1::SYNTAX.1,TRC-IMPL.1}::SYNONYMY.1::BRACE-EXPANSION.1|
+: [brace expansion][] is used for a concise designation of synonyms: ancestor
+  tag paths are separated by commas and surrounded in curly braces. Given a unit
+  with the leaf tag `T` that implements `n` ancestor  units with paths
+  `path[0]...path[n]`, the unit is tagged with
+  `|{path[0],path[1],...,path[n]}::T|`. This is equivalent to the concatenation
+  of all tag synonyms, as specified in [TRC-TAG.1::SYNTAX.1::SYNONYMY.1].
+
+Example: The previous unit implements both [TRC-TAG.1::SYNTAX.1::SYNONYMY.1]
+and [TRC-IMPL.1::SYNONYMY.1], and has the leaf tag `BRACE-EXPANSION.1`. It is
+tagged using the brace expansion syntax
+`|{TRC-TAG.1::SYNTAX.1,TRC-IMPL.1}::SYNONYMY.1::BRACE-EXPANSION.1|`, which is
+equivalent to the sequence of tags
+`|TRC-TAG.1::SYNTAX.1::SYNONYMY.1::BRACE-EXPANSION.1|
+|TRC-IMPL.1::SYNONYMY.1::BRACE-EXPANSION.1|`.
+
+[brace expansion]: www.gnu.org/software/bash/manual/html_node/Brace-Expansion.html
+
 ### 4.2. Tagging logical units
 
 |TRC-TAG.1::DEF.2|
@@ -281,4 +314,3 @@ their tags consistent.
   and thus are uniquely defined.
 
 [php-mde-deflist]: https://michelf.ca/projects/php-markdown/extra/#def-list
-

--- a/traceability/traceability.md
+++ b/traceability/traceability.md
@@ -139,7 +139,7 @@ We need a solution that satisfies the following properties:
 Example: The previous logical unit implements both [TRC-TAG.1::SYNTAX.1] and
 [TRC-IMPL.1]. As a result, it is tagged with both
 [TRC-TAG.1::SYNTAX.1::SYNONYMY.1] and [TRC-IMPL.1::SYNONYMY.1], and so these two
-tags are synonymous. However, it also bears the univocal leaf tag `SYNONYMY.1`
+tags are synonymous. However, all its tags end with the single leaf tag `SYNONYMY.1`
 
 |{TRC-TAG.1::SYNTAX.1,TRC-IMPL.1}::SYNONYMY.1::BRACE-EXPANSION.1|
 : [brace expansion][] is used for a concise designation of synonyms: ancestor

--- a/traceability/traceability.md
+++ b/traceability/traceability.md
@@ -99,8 +99,8 @@ We need a solution that satisfies the following properties:
 
 |TRC-TAG.1::SYNTAX.1|
 : We propose a simple naming scheme for tags. We start with the tags for
-  top-level requirements and then proceed with the tags of the logical units that
-  implement higher-level requirements.
+  top-level requirements and then proceed with the tags of the logical units
+  that implement lower-level requirements.
 
   **Zero-level requirement tags.** These are the tags of the requirements that
   do not implement any requirement but are the zero-level requirements

--- a/traceability/traceability.md
+++ b/traceability/traceability.md
@@ -131,7 +131,7 @@ We need a solution that satisfies the following properties:
   ancestor logical units. This gives rise to "synonyms tags". However, logical
   units with synonymous tags should always terminate with the same leaf tag.
 
-  A logical unit is tagged with synonymous tags by separating the synonymous
+  A logical unit is tagged with synonymous tags by separating the synonyms
   with a space. Given a unit with the leaf tag `T` that implements `n` ancestor
   units with paths `path[0]...path[n]`, the unit is tagged with `|path[0]::T|
   |path[1]::T| ... |path[n]::T|`.

--- a/traceability/traceability.md
+++ b/traceability/traceability.md
@@ -129,7 +129,7 @@ We need a solution that satisfies the following properties:
 |TRC-TAG.1::SYNTAX.1::SYNONYMY.1| |TRC-IMPL.1::SYNONYMY.1|
 : A logical unit may bear multiple tags, as a result of implementing multiple
   ancestor logical units. This gives rise to "synonyms tags". However, logical
-  units with synonymous tags should always have a unique leaf tag.
+  units with synonymous tags should always terminate with the same leaf tag.
 
   A logical unit is tagged with synonymous tags by separating the synonymous
   with a space. Given a unit with the leaf tag `T` that implements `n` ancestor


### PR DESCRIPTION
Without this feature, we have no way of indicating when a single logical unit
implements multiple ancestors.

Note that this generalizes the graph structure from a tree to a DAG, but I think
it must be supported.